### PR TITLE
Fetch libs from google

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
Fixes the issue where gradle sync fails because it cannot recognize design and recyclerview libs.